### PR TITLE
Fix missing / incorrect dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(VENV2_TEST_DEPS): $(VENV2)
 	. $(VENV2_ACTIVATE); pip install $(@F)
 
 $(VENV2_INSTALLED) : $(VENV2)
-	. $(VENV2_ACTIVATE); pip install -e .
+	. $(VENV2_ACTIVATE); pip install --process-dependency-links -e .
 
 test2: $(VENV2_TEST_DEPS) $(VENV2_INSTALLED)
 	. $(VENV2_ACTIVATE); $(PYTHON) -m unittest discover -s .

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.7
 
 Package: python-nmoscommon
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, python-avahi
+Depends: ${misc:Depends}, ${python:Depends}, python-avahi, python-gobject
 Description: nmos python utilities
  .
  Implementation of the nmos python utilities

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.7
 
 Package: python-nmoscommon
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, python-flask-sockets, python-flask-oauthlib, python-pybonjour
+Depends: ${misc:Depends}, ${python:Depends}, python-avahi
 Description: nmos python utilities
  .
  Implementation of the nmos python utilities

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -3,4 +3,4 @@ gevent_websocket python3-gevent-websocket
 socketio_client python3-socketio-client
 flask_sockets python3-flask-sockets
 flask_oauthlib python3-flask-oauthlib
-zmq python3-zmq
+pyzmq python3-zmq

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -1,1 +1,1 @@
-zmq python-zmq
+pyzmq python-zmq

--- a/rpm/nmoscommon.spec
+++ b/rpm/nmoscommon.spec
@@ -33,6 +33,7 @@ Requires:       python-socketio-client
 Requires:       python-flask-sockets
 Requires:       pybonjour
 Requires:       python-avahi
+Requires:       pygobject2
 Requires:       python-zmq
 Requires:       python-pygments           >= 1.6
 Requires:       python-dateutil

--- a/rpm/nmoscommon.spec
+++ b/rpm/nmoscommon.spec
@@ -32,12 +32,11 @@ Requires:       python-websocket-client   >= 0.13.0
 Requires:       python-socketio-client
 Requires:       python-flask-sockets
 Requires:       pybonjour
-Requires:       avahi
-Requires:       varnish
+Requires:       python-avahi
 Requires:       python-zmq
 Requires:       python-pygments           >= 1.6
 Requires:       python-dateutil
-Requires:       python-flask-oauthlib
+Requires:       python-flask-oauth
 Requires:       python-netifaces
 
 %description

--- a/setup.py
+++ b/setup.py
@@ -92,10 +92,13 @@ packages_required = [
     "jsonschema==2.3.0",
     "netifaces",
     "websocket-client==0.18.0",
-    "zmq"
+    "pybonjour==1.1.1"
 ]
 
-deps_required = []
+# The following are included only as the package fails to download from pip
+deps_required = [
+    "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pybonjour/pybonjour-1.1.1.tar.gz#egg=pybonjour-1.1.1"
+]
 
 
 setup(name="nmoscommon",
@@ -108,6 +111,7 @@ setup(name="nmoscommon",
       packages=package_names,
       package_dir=packages,
       install_requires=packages_required,
+      dependency_links=deps_required,
       scripts=[],
       data_files=[],
       long_description="""\


### PR DESCRIPTION
This should resolve a variety of dependency issues including an incorrect link to the avahi package on CentOS. Requires some testing as it intentionally undoes an earlier patch adding some flask dependencies in the debian/control file.