### PR TITLE
Add `fix_proxy` option to use correct HTTP/HTTPS scheme in redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # nmoscommon
 --------------
 
+- v0.3.0:
+    Added `fix_proxy` option to honour X-Fowarded-Proto in redirects.
+
 - v0.2.1:
     Fixed dependency requirements in setup.py to specify a minimum version not an exact version.

--- a/nmoscommon/webapi.py
+++ b/nmoscommon/webapi.py
@@ -37,6 +37,7 @@ import sys
 
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import BaseResponse
+from werkzeug.contrib.fixers import ProxyFix
 
 from requests.structures import CaseInsensitiveDict
 
@@ -493,6 +494,10 @@ class WebAPI(object):
         self._authenticate = self.default_authenticate
 
         self.add_routes(self, basepath='')
+
+        # Enable ProxyFix middleware if required
+        if config.get('fix_proxy', 'disabled') == 'enabled':
+            self.app.wsgi_app = ProxyFix(self.app.wsgi_app)
 
     def add_routes(self, cl, basepath):
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ deps_required = [
 
 
 setup(name="nmoscommon",
-      version="0.2.1",
+      version="0.3.0",
       description="nmos python utilities",
       url='www.nmos.tv',
       author='Peter Brightwell',


### PR DESCRIPTION
Adds the option `fix_proxy` which, when enabled, uses the Werkzeug
ProxyFix middleware to read X-Forwarded-Proto.
As a result the automatic redirect when forward slashes are missing
works properly when deployed, for example, behind an AWS ELB.