### PR TITLE
Support for configuring logging in pure python logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # nmoscommon
 --------------
 
+- v0.6.0
+    Support for configuring logging
+
 - v0.5.1
     Use cython acceleration for gevent-websocket
 

--- a/nmoscommon/nmoscommonconfig.py
+++ b/nmoscommon/nmoscommonconfig.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import json
-from .logger import Logger
 
 config = {}
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,15 @@ def create_default_conf():
         return
 
     defaultData = {
-        "priority": 0
+        "priority": 0,
+        "logging": {
+          "level": "DEBUG",
+          "fileLocation": "/var/log/nmos.log",
+          "output": [
+            "file",
+            "stdout"
+          ]
+        }
     }
 
     try:
@@ -125,7 +133,7 @@ deps_required = [
 
 
 setup(name="nmoscommon",
-      version="0.5.1",
+      version="0.6.0",
       description="nmos python utilities",
       url='www.nmos.tv',
       author='Peter Brightwell',

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -30,7 +30,7 @@ class TestLogger(unittest.TestCase):
         PurePythonLogger.logsOpened = False
 
         node_name = "test-logger"
-        
+
         with mock.patch('logging.FileHandler', side_effect=lambda _ : StreamHandler(test_stream)):
             logger = PurePythonLogger(node_name=node_name)
 
@@ -75,7 +75,7 @@ class TestLogger(unittest.TestCase):
         PurePythonLogger.logsOpened = False
 
         node_name = "test-logger"
-        
+
         with mock.patch('logging.FileHandler', side_effect=Exception):
             try:
                 logger = PurePythonLogger(node_name=node_name)


### PR DESCRIPTION
Logger can now be configured in the nmoscommon config using the following format:
```json
{
  "priority": 0,
  "logging": {
    "level": "DEBUG",
    "fileLocation": "/var/log/nmos.log",
    "output": [
      "file",
      "stdout"
    ]
  }
}
```
Where `level` sets the debug level and may be any of the python debug levels, `fileLocation` sets the log file location, and `output` sets the log output method(s) and can include `file`, `stdout`, and `stderr`. 

Default behavior has not changed but a bug has been fixed that resulted in messages being outputted twice. These changes do not affect the IppLogger when it is used.