### PR TITLE
stdeb: remove file as deps covered in debian/py3dist-overrides

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,2 +1,0 @@
-[DEFAULT]
-Depends3: python3-gevent-websocket, python3-flask-sockets, python3-pybonjour


### PR DESCRIPTION
Fixes double declaration of Python 3 dependencies