### PR TITLE
ipc: address potential for leaking FDs identified in #45

### DIFF
--- a/nmoscommon/ipc.py
+++ b/nmoscommon/ipc.py
@@ -139,6 +139,7 @@ class Proxy(object):
             gevent.sleep(0)
 
             if self.socket.poll(timeout=self.timeout) == 0:
+                self.close()
                 raise LocalException("Unconnected Socket")
 
             r = self.socket.recv_json()
@@ -150,6 +151,14 @@ class Proxy(object):
         except:
             gevent.sleep(0)
             raise
+
+    def close(self):
+        if self.socket:
+            try:
+                self.socket.close()
+            except:
+                pass
+            self.socket = None
 
     def __getattr__(self, name):
         def _invoke(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ deps_required = [
 
 
 setup(name="nmoscommon",
-      version="0.6.1",
+      version="0.6.2",
       description="nmos python utilities",
       url='www.nmos.tv',
       author='Peter Brightwell',


### PR DESCRIPTION
Suggest this needs more eyes and further testing, but I believe it should transparently handle the potential for a file descriptor leak in other code which make use of the IPC Proxy class.