### PR TITLE
deb-overrides: tidy up to include only packages which don't map directly

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,8 +1,2 @@
-gevent python3-gevent
-gevent_websocket python3-gevent-websocket
-socketio_client python3-socketio-client
-flask_sockets python3-flask-sockets
-flask_oauthlib python3-flask-oauthlib
 pyzmq python3-zmq
-ujson python3-ujson
-wsaccel python3-wsaccel
+websocket-client python3-websocket

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -1,4 +1,2 @@
 pyzmq python-zmq
 websocket-client python-websocket
-ujson python-ujson
-wsaccel python-wsaccel


### PR DESCRIPTION
Some tidy up for the overrides. Should finish off #15 