### PR TITLE
webapi: modify debug output to always be a string

### DIFF
--- a/nmoscommon/webapi.py
+++ b/nmoscommon/webapi.py
@@ -651,10 +651,10 @@ class WebAPI(object):
                 response = {
                     'code': e.code,
                     'error': e.description,
-                    'debug': {
+                    'debug': str({
                         'traceback': [str(x) for x in traceback.extract_tb(tb)],
                         'exception': [str(x) for x in traceback.format_exception_only(t, v)]
-                    }
+                    })
                 }
 
                 return IppResponse(json.dumps(response), status=e.code, mimetype='application/json')
@@ -662,10 +662,10 @@ class WebAPI(object):
             response = {
                 'code': 500,
                 'error': 'Internal Error',
-                'debug': {
+                'debug': str({
                     'traceback': [str(x) for x in traceback.extract_tb(tb)],
                     'exception': [str(x) for x in traceback.format_exception_only(t, v)]
-                }
+                })
             }
 
             return IppResponse(json.dumps(response), status=500, mimetype='application/json')

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ deps_required = [
 
 
 setup(name="nmoscommon",
-      version="0.6.8",
+      version="0.6.9",
       description="Common components for the BBC's NMOS implementations",
       url='https://github.com/bbc/nmos-common',
       author='Peter Brightwell',


### PR DESCRIPTION
This ensures we match the advertised schemas for IS-04/05 which expect 'debug' to be a string or null. I don't believe it will affect any existing users as it would be unusual to parse this attribute programmatically.