### PR TITLE
Revert "webapi: removed unused MediaType class and assistive functions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.9.5
+- Re-introduces helper functions in webapi for MIME type matching/selection
+
 ## 0.9.4
 - Bugfix to prevent un-handled errors in unicast DNS dicovery when no PTR record is present
 

--- a/nmoscommon/webapi.py
+++ b/nmoscommon/webapi.py
@@ -55,6 +55,64 @@ except:  # pragma: no cover
 
 from nmoscommon.nmoscommonconfig import config as _config
 
+class MediaType(object):
+    def __init__(self, mr):
+        comps = [ x.strip() for x in mr.split(';') ]
+        (self.type, self.subtype) = comps.pop(0).split('/')
+        self.priority = 1.0
+        self.options = []
+        self.accept_index = 0
+        for c in comps:
+            if c[0] == 'q':
+                tmp = [ x.strip() for x in c.split('=') ]
+                if tmp[0] == "q":
+                    self.priority = float(tmp[1])
+                    continue
+            self.options.append(c)
+
+    def __str__(self):
+        return "%s/%s;%s" % (self.type, self.subtype, ';'.join(self.options + [ 'q=%g' % self.priority, ]))
+
+    def __repr__(self):
+        return "MediaType(\"{}\")".format(self.__str__())
+
+    def matches(self, t):
+        if not isinstance(t, MediaType):
+            t = MediaType(t)
+        if t.type == self.type or self.type == '*':
+            if t.subtype == self.subtype or self.subtype == '*':
+                return True
+        return False
+
+def AcceptStringParser(accept_string):
+    return [MediaType(x.strip()) for x in accept_string.split(',')]
+
+def AcceptableType(mt, accept_string):
+    if not isinstance(mt, MediaType):
+        mt = MediaType(mt)
+    for idx, t in enumerate(AcceptStringParser(accept_string)):
+        if t.matches(mt):
+            t.accept_index = idx
+            return t
+    return None
+
+def MostAcceptableType(type_strings, accept_string):
+    """First parameter is a list of media type strings, the second is an HTTP Accept header string. Return
+    value is a string which corresponds to the most acceptable type out of the list provided."""
+    def __cmp(a,b):
+        if a is None and b is None:
+            return 0
+        elif a is None:
+            return 1
+        elif b is None:
+            return -1
+        elif a.priority == b.priority:
+            return cmp(a.accept_index, b.accept_index)
+        else:
+            return -cmp(a.priority, b.priority)
+
+    return sorted([ (mt, AcceptableType(MediaType(mt), accept_string)) for mt in type_strings ], cmp=lambda a,b :__cmp(a[1], b[1]))[0][0]
+
 HOST = None
 itt = 0
 

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ deps_required = []
 
 
 setup(name="nmoscommon",
-      version="0.9.4",
+      version="0.9.5",
       description="Common components for the BBC's NMOS implementations",
       url='https://github.com/bbc/nmos-common',
       author='Peter Brightwell',


### PR DESCRIPTION
This reverts commit 27feb2b0ff24202218841d090aee423f3925ad4e.

The Media Access and Store Manager APIs uses these features, so they were used after all.