### PR TITLE
Pin oauthlib < 3.0.0 to resolve conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.11.2
+- Require a version of `oauthlib` compatible with `flask-oauthlib` ([#75](https://github.com/bbc/nmos-common/issues/75))
+
 ## 0.11.1
 - Modify construction of Depends lines in stdeb
 

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,8 @@ packages_required = [
     "pyzmq>=15.2.0",
     "pygments>=1.6",
     "python-dateutil>=2.4.2",
+    "oauthlib<3.0.0",
+    "requests-oauthlib<1.2.0",
     "flask-oauthlib>=0.9.1",
     "ws4py>=0.3.2",
     "requests>=2.6",
@@ -158,7 +160,7 @@ deps_required = []
 
 
 setup(name="nmoscommon",
-      version="0.11.1",
+      version="0.11.2",
       description="Common components for the BBC's NMOS implementations",
       url='https://github.com/bbc/nmos-common',
       author='Peter Brightwell',


### PR DESCRIPTION
`flask-oauthlib` requires a version of `oauthlib<3.0.0` (ish - there are some other restrictions too).
Also pins `requests-oauthlib<1.2.0` to keep it compatible with `oauthlib<3.0.0` (see https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst#v120-14-january-2019)
Fixes #75