### PR TITLE
Correct heartbeat frequency when mDNS announcements are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.17.0
+- Fix heartbeat frequency. Requires use of 'stop' method in MDNSUpdater
+
 ## 0.16.0
 - Add basic mechanism to discover current Registration API
 

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ deps_required = []
 
 
 setup(name="nmoscommon",
-      version="0.16.0",
+      version="0.17.0",
       description="Common components for the BBC's NMOS implementations",
       url='https://github.com/bbc/nmos-common',
       author='Peter Brightwell',


### PR DESCRIPTION
This fixes an issue where a Reg API heartbeat can take around 8 seconds rather than 5 as it's held up by the creation or removal of a Node P2P mDNS announcement. The mDNS announcement is now handled in a separate greenlet.

A corresponding change to the Node needs to go in at approximately the same time to shut this spawned greenlet down, again highlighting that this file would be better placed in the Node API's repo.