### PR TITLE
aggregator: linting fix which could affect behaviour

### DIFF
--- a/nmoscommon/aggregator.py
+++ b/nmoscommon/aggregator.py
@@ -254,7 +254,7 @@ class Aggregator(object):
                 self._mdns_updater.P2P_disable()
         except Exception as e:
             self.logger.writeWarning("Error re-registering Node: {}".format(e))
-            self.aggregator == "" # Fallback to prevent us getting stuck if the Reg API issues a 4XX error incorrectly
+            self.aggregator = ""  # Fallback to prevent us getting stuck if the Reg API issues a 4XX error incorrectly
             return
 
         # Re-register items that must be ordered


### PR DESCRIPTION
This line is intended to force a re-discovery of a Reg API if
we receive a 4XX error from it during initial (re-)registration.
Assuming our Node schema validates this will only occur due to an
implementation error in the Reg API and is intended to prevent
use getting stuck contacting that instance when others may work
properly.

The line has clearly never done its job, but it doesn't appear
that enabling it will do any harm as in the worst case it will
cause the same Reg API to be found again via the mDNS bridge on
the next iteration.