### PR TITLE
Dannym downgradeapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.19.12
+- Add `downgrade_api_version` common function to utils
+
 ## 0.19.11
 - Fix bug when requesting auth server url using mDNS
 

--- a/nmoscommon/utils.py
+++ b/nmoscommon/utils.py
@@ -22,6 +22,8 @@ import netifaces
 
 from .logger import Logger
 
+logger = Logger("utils", None)
+
 DOWNGRADE_MAP = {
     "v1.1": {
         "node": ["description", "tags", "api", "clocks"],
@@ -47,7 +49,6 @@ DOWNGRADE_MAP = {
 
 
 def get_node_id():
-    logger = Logger("utils", None)
     node_id_path = "/var/nmos-node/facade.json"
     node_id = str(uuid.uuid1())
     try:
@@ -99,7 +100,7 @@ def downgrade_api_version(
 
     # Downgrade API object, for a given resource, until it reaches target_version
     while api_ver_compare(target_ver, current_api_version) < 0:
-        print("Processing downgrading from {}".format(current_api_version))
+        logger.writeDebug("Processing downgrading from {}".format(current_api_version))
         obj = remove_keys_from_resource(obj, rtype, downgrade_map[current_api_version])
         current_api_version = version_list[version_list.index(current_api_version) - 1]
 

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ deps_required = []
 
 setup(
     name="nmoscommon",
-    version="0.19.11",
+    version="0.19.12",
     description="Common components for the BBC's NMOS implementations",
     url='https://github.com/bbc/nmos-common',
     author='Peter Brightwell',


### PR DESCRIPTION
Added a common utility function for downgrading API's... takes a param `downgrade_map` with the list of keys that have been added for each api version release

e.g.
```
downgrade_map = {
        "v1.1": {
            "node": ["description", "tags", "api", "clocks"],
            "device": ["description", "tags", "controls"],
            "source": ["clock_name", "grain_rate", "channels"],
            "frame_height", "interlace_mode", "colorspace", "components", "transfer_characteristic"
            ],
        },
        "v1.2": {
            "node": ["interfaces"],
            "sender": ["interface_bindings", "caps", "subscription"],
            "receiver": ["interface_bindings"]
    }
}