### PR TITLE
Pin back dateutil to <2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.19.16
+- Pin back dateutil dependency to <2.8.1 to avoid downstream issue with boto3.
+
 ## 0.19.15
 - Avoid OPTIONS being added to both trailing slash and non trailing slash API paths causing non-deterministic routing
 

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ deps_required = []
 
 setup(
     name="nmoscommon",
-    version="0.19.15",
+    version="0.19.16",
     description="Common components for the BBC's NMOS implementations",
     url='https://github.com/bbc/nmos-common',
     author='Peter Brightwell',

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ packages_required = [
     "flask-sockets>=0.1",
     "pyzmq>=15.2.0",
     "pygments>=1.6",
-    "python-dateutil>=2.4.2",
+    "python-dateutil>=2.4.2,<2.8.1",
     "oauthlib<3.0.0",
     "requests-oauthlib<1.2.0",
     "flask-oauthlib>=0.9.1",


### PR DESCRIPTION
Avoids triggering a downstream issue where nmoscommon is used with boto3 (https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9)