### PR TITLE
mdns: periodically purge stale entries from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.19.18
+- Clear mDNS announcements from hosts which have terminated ungracefully
+
 ## 0.19.17
 - Make behaviour of getLocalIP() consistent with mdns interface selection
 

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ deps_required = []
 
 setup(
     name="nmoscommon",
-    version="0.19.17",
+    version="0.19.18",
     description="Common components for the BBC's NMOS implementations",
     url='https://github.com/bbc/nmos-common',
     author='Peter Brightwell',


### PR DESCRIPTION
This change periodically (once per hour) checks that each mDNS service we hold a record for is still resolvable.