### PR TITLE
Pin back werkzeug version to avoid flask issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Common Library Changelog
 
+## 0.19.20
+- Pin back werkzeug dependency to <1.0.0 to avoid downstream issue with flask.
+
 ## 0.19.19
 - Update nmos_auth to validate tokens using  JSON Web Keys endpoint
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ packages_required = [
     "six>=1.10.0",
     "flask>=0.10.1",
     "jinja2>=2.7.2",
-    "werkzeug>=0.14.1",
+    "werkzeug>=0.14.1,<1.0.0",
     "itsdangerous>=0.24",
     "socketio-client>=0.5.3",
     "flask-sockets>=0.1",
@@ -179,7 +179,7 @@ deps_required = []
 
 setup(
     name="nmoscommon",
-    version="0.19.19",
+    version="0.19.20",
     description="Common components for the BBC's NMOS implementations",
     url='https://github.com/bbc/nmos-common',
     author='Peter Brightwell',


### PR DESCRIPTION
Werkzeug have released version 1.0.0: https://pypi.org/project/Werkzeug/1.0.0/. The API has changed and this causes issues in the flask packages. E.g.
```
File "/vagrant/src/serviceapi/.tox/py3/lib/python3.6/site-packages/nmoscommon/webapi.py", line 53, in <module>
    import flask_oauthlib.client
  File "/vagrant/src/serviceapi/.tox/py3/lib/python3.6/site-packages/flask_oauthlib/client.py", line 18, in <module>
    from werkzeug import url_quote, url_decode, url_encode
ImportError: cannot import name 'url_quote'
```

The werkzeug release notes has an item that explains: `Remove most top-level attributes provided by the werkzeug module in favor of direct imports. For example, instead of import werkzeug; werkzeug.url_quote, do from werkzeug.urls import url_quote. Install version 0.16 first to see deprecation warnings while upgrading.`