### PR TITLE
Pin mock version to workaround mocking issues

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
     coverage report
 deps =
     coverage
-    mock
+    mock < 4.0.0
 install_command = pip install {opts} {packages}
 
 [testenv:py3]
@@ -28,5 +28,5 @@ commands =
     coverage report
 deps =
     coverage
-    mock
+    mock < 4.0.0
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
A new major release of the `mock` package was made Feb 5: https://pypi.org/project/mock/4.0.0/. The new version results in tests failing as shown in the example below.

This PR pins the version back to < 4.0.0 (3.0.5) and this avoids the test errors.

A longer term solution would be to follow the suggestions made in the Flask documentation: https://flask.palletsprojects.com/en/1.1.x/reqcontext/#manually-push-a-context.

```
======================================================================
ERROR: test_methods_overrides_get (test_flask_cors.TestCrossDomain)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/tmp/jenkins/workspace/apmm-repos_nmos-common_master/tests/test_flask_cors.py", line 116, in test_methods_overrides_get
    self.assert_crossdomain_call_correct("GET", methods=[ "GET", "PUT", "POTATO" ])
  File "/var/tmp/jenkins/workspace/apmm-repos_nmos-common_master/tests/test_flask_cors.py", line 43, in assert_crossdomain_call_correct
    with mock.patch('nmoscommon.flask_cors.current_app') as current_app:
  File "/tmp/apmm-repos_nmos-common_master/tox-py3/py3/lib/python3.6/site-packages/mock/mock.py", line 1460, in __enter__
    if spec is None and _is_async_obj(original):
  File "/tmp/apmm-repos_nmos-common_master/tox-py3/py3/lib/python3.6/site-packages/mock/mock.py", line 52, in _is_async_obj
    if hasattr(obj, '__func__'):
  File "/tmp/apmm-repos_nmos-common_master/tox-py3/py3/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/tmp/apmm-repos_nmos-common_master/tox-py3/py3/lib/python3.6/site-packages/werkzeug/local.py", line 307, in _get_current_object
    return self.__local()
  File "/tmp/apmm-repos_nmos-common_master/tox-py3/py3/lib/python3.6/site-packages/flask/globals.py", line 52, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
to interface with the current application object in some way. To solve
this, set up an application context with app.app_context().  See the
documentation for more information.
```